### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ You should probably also add `:toc:` at the top of your document, to ensure that
 
 Clone this https://github.com/spring-guides/topical-guides[repository]
 and edit the README to contain the content of your guide. Currently we
-can only support guides in Asciidoctor[http://asciidoctor.org/] but
+can only support guides in Asciidoctor[https://asciidoctor.org/] but
 Markdown[https://guides.github.com/features/mastering-markdown/]
 support is planned. Add images, code, etc. directly in your fork. You
 are encouraged to use advanced features of Asciidoctor if you need


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org/ with 1 occurrences migrated to:  
  https://asciidoctor.org/ ([https](https://asciidoctor.org/) result 200).
* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).